### PR TITLE
Import browser-source-map-support in development

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ module.exports = {
     nodeAssets: {
       "source-map-support": function() {
         return {
-          enabled: this.app.env === 'test',
+          enabled: this.app.env !== 'production',
           import: ['browser-source-map-support.js']
         };
       }


### PR DESCRIPTION
As it was, in development environment it was not including browser-source-map-support.js hence when running `localhost:4200/tests` in development mode a global failure was shown.
