### PR TITLE
Convert `ember-cli-babel` to dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "test": "ember try:each"
   },
   "dependencies": {
-    "ember-cli-babel": "^6.6.0",
     "ember-cli-node-assets": "^0.1.4",
     "source-map-support": "^0.4.2"
   },
@@ -33,6 +32,7 @@
     "broccoli-asset-rev": "^2.4.5",
     "ember-ajax": "^3.0.0",
     "ember-cli": "~2.16.2",
+    "ember-cli-babel": "^6.6.0",
     "ember-cli-dependency-checker": "^2.0.0",
     "ember-cli-eslint": "^4.0.0",
     "ember-cli-htmlbars": "^2.0.1",


### PR DESCRIPTION
`ember-cli-babel` is only needed as a prod dependency if there are files in the `addon` folder, which is not the case here. This PR converts it to a dev dependency so that the (empty) dummy app is still built correctly.

/cc @san650 